### PR TITLE
Pass through XX-Cf-app-instance as x-cf-app-instance

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,6 +47,11 @@ http {
 
     location / {
       resolver 10.0.0.2;
+
+      # gorouter strips the X-CF-APP-INSTANCE header on the first pass through,
+      # so we allow XX-CF-APP-INSTANCE to do the same job on the second pass
+      # to actually target an app instance
+      proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;
       proxy_pass $http_x_cf_forwarded_url;
     }
   }


### PR DESCRIPTION
We've seen weird behaviour (that's difficult to reproduce) where
binding a route service to a route causes the x-cf-app-instance header
to fail to route to the requested instance.  We suspect that this is
because:

 - when you have a route service, your request goes through gorouter
   twice
 - on the first pass through, the x-cf-app-instance header is consumed
   and stripped, then your request goes to the route service
 - on the second pass through, the header is missing, so gorouter
   randomly picks an instance to send the request to

As an ugly workaround, this commit allows you to specify
XX-cf-app-instance instead, which will not be stripped on the first
pass through gorouter, then the route service sets x-cf-app-instance
from this header, so that the second pass through gorouter will get
the required value in the x-cf-app-instance header and route to the
correct instance.