### PR TITLE
Simplify deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+---
+name: Test
+
+on: ["pull_request"]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Check shell script
+        run: shellcheck ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ space.
 
 Edit the `manifest.yml` and change the `ALLOWED_IPS` as appropriate.
 
-## Deployment
+## Deployment by hand
 
 To deploy the app, run `cf push`.
 
@@ -36,6 +36,18 @@ If you want to add a custom route, add a route definition to the manifest:
     routes:
       - route: my-subdomain.my-domain.com
     ...
+```
+
+## Deployment by script
+
+This repository provides a script that will deploy and configure this route service for you. See the example below for how to use it.
+
+```shell script
+ALLOWED_IPS="comma_separated_list_of_ips_eg_1.2.3.4,5.6.7.8" \
+ROUTE_SERVICE_APP_NAME="name_of_the_app_to_push" \
+ROUTE_SERVICE_NAME="name_of_the_route_service_to_create" \
+PROTECTED_APP_NAME="name_of_the_app_to_protect" \
+./deploy.sh
 ```
 
 ## Use the app as a route service

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null; then
+  echo "Must have JQ installed"
+  exit 1
+fi
+
+if [ -z "${ALLOWED_IPS+set}" ]; then
+  echo "Must set ALLOWED_IPS environment variable to a comma separated list of IP addresses"
+  exit 1
+fi
+
+if [ -z "${ROUTE_SERVICE_APP_NAME+set}" ]; then
+  echo "Must set ROUTE_SERVICE_APP_NAME environment variable"
+  exit 1
+fi
+
+if [ -z "${ROUTE_SERVICE_NAME+set}" ]; then
+  echo "Must set ROUTE_SERVICE_NAME environment variable"
+  exit 1
+fi
+
+if [ -z "${PROTECTED_APP_NAME+set}" ]; then
+  echo "Must set PROTECTED_APP_NAME environment variable"
+  exit 1
+fi
+
+IFS="," read -ra IPS <<< "$ALLOWED_IPS"
+
+NGINX_ALLOW_STATEMENTS=""
+for addr in "${IPS[@]}";
+  do NGINX_ALLOW_STATEMENTS="$NGINX_ALLOW_STATEMENTS \n allow $addr;"; true;
+done;
+
+APPS_DOMAIN=$(cf curl "/v3/domains" | jq -r '[.resources[] | select(.name|endswith("apps.digital"))][0].name')
+
+cf push "${ROUTE_SERVICE_APP_NAME}" --no-start --var app-name="${ROUTE_SERVICE_APP_NAME}"
+cf set-env "${ROUTE_SERVICE_APP_NAME}" ALLOWED_IPS "$(printf "%s" "${NGINX_ALLOW_STATEMENTS}")"
+cf start "${ROUTE_SERVICE_APP_NAME}"
+
+ROUTE_SERVICE_DOMAIN="$(cf curl "/v3/apps/$(cf app "${ROUTE_SERVICE_APP_NAME}" --guid)/routes" | jq -r --arg APPS_DOMAIN "${APPS_DOMAIN}" '[.resources[] | select(.url | endswith($APPS_DOMAIN))][0].url')"
+
+if cf curl "/v3/service_instances?type=user-provided&names=${ROUTE_SERVICE_NAME}" | jq -e '.pagination.total_results == 0' > /dev/null; then
+  cf create-user-provided-service \
+    "${ROUTE_SERVICE_NAME}" \
+    -r "https://${ROUTE_SERVICE_DOMAIN}";
+else
+  cf update-user-provided-service \
+    "${ROUTE_SERVICE_NAME}" \
+    -r "https://${ROUTE_SERVICE_DOMAIN}";
+fi
+
+PROTECTED_APP_HOSTNAME="$(cf curl "/v3/apps/$(cf app "${PROTECTED_APP_NAME}" --guid)/routes" | jq -r --arg APPS_DOMAIN "${APPS_DOMAIN}" '[.resources[] | select(.url | endswith($APPS_DOMAIN))][0].host')"
+
+cf bind-route-service "${APPS_DOMAIN}" "${ROUTE_SERVICE_NAME}" --hostname "${PROTECTED_APP_HOSTNAME}";


### PR DESCRIPTION
What
---
Introduce `deploy.sh` which does the heavy lifting of deploying the IP authentication route service

How to review
---
We trust that the IP restriction code as written functions correctly.

1. Deploy a static file app, or some other basic app you can access
2. Follow the README instructions to deploy the route service with 2 allowed IPs. E.g. `1.2.3.4,5.6.7.8`
3. Check that the pushed app's `ALLOWED_IPS` environment variable has two nginx `allow` statements as its value, containing the IP addresses you set.
4. Visit the protected app's route, and check it says `Forbidden by ${APP_NAME}`