### PR TITLE
Add Fastly IP addresses to nginx config ngx_http_realip_module

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,26 @@ http {
   set_real_ip_from 127.0.0.1/32;
   set_real_ip_from 172.16.0.0/12;
   set_real_ip_from 192.168.0.0/16;
+  # Fastly IPv4 and IPv6 addresses, via https://api.fastly.com/public-ip-list
+  set_real_ip_from 23.235.32.0/20;
+  set_real_ip_from 43.249.72.0/22;
+  set_real_ip_from 103.244.50.0/24;
+  set_real_ip_from 103.245.222.0/23;
+  set_real_ip_from 103.245.224.0/24;
+  set_real_ip_from 104.156.80.0/20;
+  set_real_ip_from 146.75.0.0/16;
+  set_real_ip_from 151.101.0.0/16;
+  set_real_ip_from 157.52.64.0/18;
+  set_real_ip_from 167.82.0.0/17;
+  set_real_ip_from 167.82.128.0/20;
+  set_real_ip_from 167.82.160.0/20;
+  set_real_ip_from 167.82.224.0/20;
+  set_real_ip_from 172.111.64.0/18;
+  set_real_ip_from 185.31.16.0/22;
+  set_real_ip_from 199.27.72.0/21;
+  set_real_ip_from 199.232.0.0/16;
+  set_real_ip_from 2a04:4e40::/32;
+  set_real_ip_from 2a04:4e42::/32;
   real_ip_recursive on;
 
   server {


### PR DESCRIPTION
When visiting https://staging.data.gov.uk/ (which is behind
Fastly), we're seeing "Forbidden by ip-authentication-route-service"
even when connecting via VPN.

This is because the route service is seeing Fastly's IP as the original
IP, rather than our own. Our [ngx_http_realip_module](http://nginx.org/en/docs/http/ngx_http_realip_module.html)
configuration checks the `X_FORWARDED_FOR` header and defines the IPs
in the header that [should be ignored](https://github.com/alphagov/paas-ip-authentication-route-service/blob/f493d05ed5bd56fee5736f03f1b007173b05f7f7/nginx.conf#L36-L39),
in theory just leaving the client IP, which is then subject to the
[`ALLOWED_IPS` list](https://github.com/alphagov/paas-ip-authentication-route-service/blob/92025d1a20cf66e6a4560ea8d5ac39e1a6c10257/README.md#L46).
We're currently not stripping out the Fastly IPs, so are mistakenly
treating this as the client IP, which has not been allow-listed.

More background information below:

Checking the output of `cf logs --recent ip-authentication-route-service`,
we can see:

```
   2021-03-09T09:13:55.00+0000 [APP/PROC/WEB/0] ERR 2021/03/09 09:13:55 [error] 101#0: *1744 access forbidden by rule, client: 157.52.69.68, server: localhost, request: "GET / HTTP/1.1", host: "ip-authentication-route-service.cloudapps.digital"
   2021-03-09T09:13:55.00+0000 [RTR/2] OUT ip-authentication-route-service.cloudapps.digital - [2021-03-09T09:13:54.994233707Z] "GET / HTTP/1.1" 403 0 44 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36" "127.0.0.1:29076" "10.0.32.5:61084" x_forwarded_for:"213.86.153.214, 213.86.153.214, 157.52.69.68, 10.0.2.142, 127.0.0.1" x_forwarded_proto:"https" vcap_request_id:"96362a2b-e055-42ad-6e53-81ac5b5384d7" response_time:0.009879 gorouter_time:0.000115 app_id:"13bab139-ce27-4909-96ad-7d9832723f99" app_index:"0" x_cf_routererror:"-" x_b3_traceid:"4fa01a6ed0ebddcf" x_b3_spanid:"4fa01a6ed0ebddcf" x_b3_parentspanid:"-" b3:"4fa01a6ed0ebddcf-4fa01a6ed0ebddcf"
   2021-03-09T09:13:55.00+0000 [RTR/2] OUT
```