### PR TITLE
Avoid newlines in nginx config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ IFS="," read -ra IPS <<< "$ALLOWED_IPS"
 
 NGINX_ALLOW_STATEMENTS=""
 for addr in "${IPS[@]}";
-  do NGINX_ALLOW_STATEMENTS="$NGINX_ALLOW_STATEMENTS \n allow $addr;"; true;
+  do NGINX_ALLOW_STATEMENTS="${NGINX_ALLOW_STATEMENTS} allow $addr;"; true;
 done;
 
 APPS_DOMAIN=$(cf curl "/v3/domains" | jq -r '[.resources[] | select(.name|endswith("apps.digital"))][0].name')


### PR DESCRIPTION
Using \n characters as separators for allow statements in the nginx config file
causes a syntax error and prevents the buildpack from being built. But removing the
newlines works and results in the allow lines to be all on the same line, which
doesn't substantially reduce the readability of the file.